### PR TITLE
:bug: s/maxCandidates/maxItems

### DIFF
--- a/nvim/userautoload/toml/lazy/ddc.vim.toml
+++ b/nvim/userautoload/toml/lazy/ddc.vim.toml
@@ -53,7 +53,7 @@ call ddc#custom#patch_global('sourceOptions', {
   \ '_': {
   \   'ignoreCase': v:true,
   \   'minAutoCompleteLength': 1,
-  \   'maxCandidates': 50,
+  \   'maxItems': 50,
   \   'matchers': ['matcher_bitap'],
   \   'sorters': ['sorter_bitap'],
   \ }


### PR DESCRIPTION
fix [ddc Invalid sourceOptions: "maxCandidates"](https://scrapbox.io/takker/ddc_Invalid_sourceOptions:_"maxCandidates")