### PR TITLE
🐛 Enable to use WSLg

### DIFF
--- a/nvim/userautoload/init/basic.vim
+++ b/nvim/userautoload/init/basic.vim
@@ -22,22 +22,6 @@ set autochdir
 set guioptions+=a
 set clipboard^=unnamed,unnamedplus
 
-
-if system('uname -a | grep microsoft') != ''
-  let g:clipboard = {
-  \   'name': 'WslClipboard',
-  \   'copy': {
-  \        '+': ['sh','-c','nkf -sc | clip.exe'],
-  \        '*': ['sh','-c','nkf -sc | clip.exe'],
-  \    },
-  \   'paste': {
-  \      '+': 'powershell.exe -c [Console]::OutputEncoding = [Text.Encoding]::UTF8;[Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
-  \      '*': 'powershell.exe -c [Console]::OutputEncoding = [Text.Encoding]::UTF8;[Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
-  \   },
-  \   'cache_enabled': 0,
-  \ }
-endif
-
 " vim が作る一時ファイルの場所
 set directory=$XDG_CONFIG_HOME/nvim/.temp
 set viminfo+=n$XDG_CONFIG_HOME/nvim/.temp/viminfo.txt

--- a/variables.sh
+++ b/variables.sh
@@ -4,4 +4,4 @@ export PATH="$DENO_INSTALL/bin:$PATH"
 export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="$HOME/.npm-global/bin:$PATH"
 export XDG_CONFIG_HOME="$HOME/.config"
-export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0
+export DISPLAY=:0


### PR DESCRIPTION
https://github.com/microsoft/wslg/wiki/Diagnosing-%22cannot-open-display%22-type-issues-with-WSLg のトラブルシューティングに沿って修正を施した。
これで`xsel`が使えるようになったため、 `wslClipboard`は不要になった。