### PR TITLE
docs: translate Japanese comments and descriptions into English

### DIFF
--- a/.commit_template
+++ b/.commit_template
@@ -59,10 +59,10 @@
 #
 # cf. https://qiita.com/magicant/items/882b5142c4d5064933bc
 #
-# - Allow login passwords longer than 20 characters (20 文字より長いログインパスワードを認める)
-# - Recache password database after changing password (パスワード変更後データベースをキャッシュし直す)
-# - Animate thumbnail images when they appear (サムネイル画像が現れる時アニメーションさせる)
-# - Trim thumbnail images larger than 200x200 px (200x200 px より大きいサムネイル画像を切り落とす)
+# - Allow login passwords longer than 20 characters
+# - Recache password database after changing password
+# - Animate thumbnail images when they appear
+# - Trim thumbnail images larger than 200x200 px
 #
 # ==== The Seven Rules ====
 # 1. Separate subject from body with a blank line
@@ -84,4 +84,4 @@
 #
 # how to commit:
 #
-# - [クリアなコードの作り方: 意図が伝わるコミットのしかた](https://www.clear-code.com/blog/2012/3/13.html)
+# - [How to write clear code: committing with intent](https://www.clear-code.com/blog/2012/3/13.html)

--- a/.inputrc
+++ b/.inputrc
@@ -1,29 +1,29 @@
 # .inputrc
 
-# vi modeで使う
+# Use vi mode
 set editing-mode vi
 
 # cf. https://marmooo.blogspot.com/2017/08/inputrc.html
 # cf. http://blog.digital-bot.com/blog/2013/08/30/more-useful-inputrc/
-# beep音を消す
+# Turn off the beep sound
 set bell-style none
 
-# 補間時大文字小文字無視
+# Ignore case when completing
 set completion-ignore-case on
 
-# 入力候補リストのディレクトリや実行可能ファイルに印をつける
+# Mark directories and executable files in the completion list
 set visible-stats on
 
-# ファイルタイプをカラフルに
+# Colorize file types
 set colored-stats on
-# 補完の接頭辞をカラフルに
+# Colorize the completion prefix
 set colored-completion-prefix on
 
 $if Bash
-    # スペースで特殊変数がその場で展開
+    # Expand special variables in place with space
     space: magic-space
 
-    # キーバインド key: "hoge"でhogeが展開される
+    # Key bindings: the key expands the string on the right
     "\C-x\C-p": " | percol"
     "\C-^": "~/"
 $endif

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# DOTFILES_DIR は環境変数か第1引数で上書きできる
+# DOTFILES_DIR can be overridden via an environment variable or the first argument
 DOTFILES_DIR="${1:-${DOTFILES_DIR:-${HOME}/git/dotfiles}}"
 
-# bootstrap: リポジトリ未取得なら clone してから install.sh を再実行する
+# bootstrap: if the repository has not been cloned yet, clone it and re-run install.sh
 if [ ! -d "${DOTFILES_DIR}/.git" ]; then
-  echo "dotfiles を ${DOTFILES_DIR} に clone します..."
+  echo "Cloning dotfiles to ${DOTFILES_DIR}..."
   if ! command -v git >/dev/null 2>&1; then
-    echo "git が見つかりません。先に git をインストールしてください" >&2
+    echo "git not found. Please install git first." >&2
     exit 1
   fi
   mkdir -p "$(dirname "${DOTFILES_DIR}")"
@@ -23,22 +23,22 @@ LOCAL_BIN="${HOME}/.local/bin"
 NIX_PROFILE="${HOME}/.nix-profile"
 echo "== dotfiles install: start =="
 
-# 1) Nix インストール確認・インストール（multi-user 推奨）
+# 1) Check for Nix and install it if missing (multi-user recommended)
 if ! command -v nix >/dev/null 2>&1; then
-  echo "Nix が見つかりません。Nix を multi-user でインストールします（sudo が必要）..."
+  echo "Nix not found. Installing Nix with multi-user support (sudo required)..."
   curl -L https://nixos.org/nix/install | sh -s -- --daemon
-  echo "Nix インストール完了。シェル初期化を読み込みます..."
+  echo "Nix installation complete. Loading shell initialization..."
 else
-  echo "Nix は既にインストール済みです。"
+  echo "Nix is already installed."
 fi
 
-# 2) Nix プロファイル初期化（存在すれば source）
+# 2) Initialize Nix profile (source it if present)
 if [ -f "${NIX_PROFILE}/etc/profile.d/nix.sh" ]; then
   # shellcheck source=/dev/null
   . "${NIX_PROFILE}/etc/profile.d/nix.sh"
 fi
 
-# 3) ~/.profile に PATH と local bin を追加（冪等に）
+# 3) Add PATH and local bin to ~/.profile (idempotently)
 mkdir -p "${LOCAL_BIN}"
 
 NIX_PATH_LINE='export PATH="$HOME/.nix-profile/bin:$PATH"'
@@ -46,12 +46,12 @@ LOCALBIN_LINE='export PATH="$HOME/.local/bin:$PATH"'
 
 grep -Fxq "$NIX_PATH_LINE" "${PROFILE}" 2>/dev/null || {
   printf "\n# Added by dotfiles/install.sh\n%s\n" "$NIX_PATH_LINE" >> "${PROFILE}"
-  echo "-> ${PROFILE} に Nix PATH を追加しました"
+  echo "-> Added Nix PATH to ${PROFILE}"
 }
 
 grep -Fxq "$LOCALBIN_LINE" "${PROFILE}" 2>/dev/null || {
   printf "%s\n" "$LOCALBIN_LINE" >> "${PROFILE}"
-  echo "-> ${PROFILE} に ~/.local/bin を追加しました"
+  echo "-> Added ~/.local/bin to ${PROFILE}"
 }
 
 # source again to ensure current shell has PATH updated
@@ -60,15 +60,15 @@ if [ -f "${PROFILE}" ]; then
   . "${PROFILE}" || true
 fi
 
-# 4) home-manager を明示的に実行（フレークは絶対パスで指定）
-echo "home-manager を適用します（flake: ${FLAKE_REF}）..."
+# 4) Run home-manager explicitly (flake specified by absolute path)
+echo "Applying home-manager (flake: ${FLAKE_REF})..."
 # Ensure Nix experimental features (nix-command, flakes) are enabled for this user
 NIX_CONF_DIR="${HOME}/.config/nix"
 NIX_CONF_FILE="${NIX_CONF_DIR}/nix.conf"
 mkdir -p "${NIX_CONF_DIR}"
 if [ ! -f "${NIX_CONF_FILE}" ]; then
   printf "experimental-features = nix-command flakes\n" > "${NIX_CONF_FILE}"
-  echo "-> ${NIX_CONF_FILE} を作成して experimental-features を有効化しました"
+  echo "-> Created ${NIX_CONF_FILE} and enabled experimental-features"
 else
   # Add missing flags if needed
   if ! grep -q "nix-command" "${NIX_CONF_FILE}" || ! grep -q "flakes" "${NIX_CONF_FILE}"; then
@@ -76,14 +76,14 @@ else
     grep -v "^experimental-features" "${NIX_CONF_FILE}" > "${NIX_CONF_FILE}.tmp" || true
     mv "${NIX_CONF_FILE}.tmp" "${NIX_CONF_FILE}"
     printf "experimental-features = nix-command flakes\n" >> "${NIX_CONF_FILE}"
-    echo "-> ${NIX_CONF_FILE} に experimental-features を追記しました"
+    echo "-> Appended experimental-features to ${NIX_CONF_FILE}"
   fi
 fi
 
 # use nix run to ensure home-manager is available
 nix run "${DOTFILES_DIR}#home-manager" -- switch --flake "${FLAKE_REF}"
 
-# 5) wrapper スクリプト作成（どのディレクトリからでも flake 操作できるように）
+# 5) Create wrapper scripts (to run flake operations from any directory)
 cat > "${LOCAL_BIN}/dotfiles-update" <<EOF
 #!/usr/bin/env bash
 nix run ${DOTFILES_DIR}#update
@@ -98,7 +98,7 @@ chmod +x "${LOCAL_BIN}/dotfiles-switch"
 
 echo "-> wrapper scripts installed to ${LOCAL_BIN}: dotfiles-update, dotfiles-switch"
 
-# 6) bashrc スニペット: interactive shell のみで fish に切り替える
+# 6) bashrc snippet: switch to fish only in interactive shells
 BASHRC_MARK="# Added by dotfiles/install.sh: exec fish for interactive login"
 BASHRC_SNIPPET='case "$-" in
   *i*)
@@ -113,14 +113,14 @@ if ! grep -Fq "$BASHRC_MARK" "${BASHRC}" 2>/dev/null; then
     printf "\n%s\n" "$BASHRC_MARK"
     printf "%s\n" "$BASHRC_SNIPPET"
   } >> "${BASHRC}"
-  echo "-> ${BASHRC} に exec fish スニペットを追加しました"
+  echo "-> Added exec fish snippet to ${BASHRC}"
 else
-  echo "-> ${BASHRC} に既に exec fish スニペットがあります"
+  echo "-> exec fish snippet already present in ${BASHRC}"
 fi
 
-# 7) Ubuntu の場合、システムのロケールとタイムゾーンを設定
+# 7) Set the system locale and timezone on Ubuntu
 if grep -qi "^ID=ubuntu$" /etc/os-release 2>/dev/null; then
-  echo "Ubuntu を検出しました。システムのロケール/タイムゾーンを設定します..."
+  echo "Ubuntu detected. Setting the system locale/timezone..."
   nix run "${DOTFILES_DIR}#setupLang"
 fi
 

--- a/nvim/ginit.vim
+++ b/nvim/ginit.vim
@@ -1,13 +1,13 @@
-"文字コードをUFT-8に設定
+" Set character encoding to UTF-8
 scriptencoding utf-8
 
 GuiFont! Consolas:h11
 
-" ウィンドウの縦幅
+" Window height
 " set lines=55
-" ウィンドウの横幅
+" Window width
 " set columns=180
-" カラースキーム
+" Color scheme
 autocmd ColorScheme * highlight Comment ctermfg=22 guifg=#008800
 autocmd ColorScheme * highlight Search term=reverse cterm=reverse ctermfg=166 gui=reverse guifg=#FF8C00
 if has('multi_byte_ime')
@@ -17,7 +17,7 @@ endif
 colorscheme molokai
 
 set termguicolors
-" ダーク系のカラースキームを使う
+" Use a dark color scheme
 set background=dark
 highlight! Normal ctermbg=NONE guibg=NONE
 highlight! NonText ctermbg=NONE guibg=NONE

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -4,7 +4,7 @@
 "     for Unix:     $HOME/.config/nvim/init.vim
 "     for Windows:  %LOCALAPPDATA%\nvim\init.vim
 "
-"文字コードをUFT-8に設定
+" Set character encoding to UTF-8
 set encoding=utf-8
 scriptencoding utf-8
 

--- a/nvim/userautoload/init/ImDisable.ahk
+++ b/nvim/userautoload/init/ImDisable.ahk
@@ -1,10 +1,10 @@
-; insert mode を抜ける時にIMEをOFFにするための script
+; Script to turn off the IME when leaving insert mode
 GoSub,imeOn
 return
 
 imeOn:
     GoSub,GetIMEState
-    ;Msgbox, %ime_state% `n 0はOFF `n 1はON
+    ;Msgbox, %ime_state% `n 0 means OFF `n 1 means ON
     if(ime_state=1)
     {
     Send {vkF4sc029}    ; ZenHan

--- a/nvim/userautoload/init/basic.vim
+++ b/nvim/userautoload/init/basic.vim
@@ -1,4 +1,4 @@
-"文字コードをUFT-8に設定
+" Set character encoding to UTF-8
 scriptencoding utf-8
 
 " if has('win32') || has('win64')
@@ -6,7 +6,7 @@ scriptencoding utf-8
 "     let g:python_host_prog = 'C:\Python27amd64\python.exe'
 " endif
 
-" gitで管理しているnvimへのdirectory path
+" Path to the git-managed nvim directory
 let g:nvim_git_dir_path = expand('<sfile>:p:h:h:h')
 
 " encodings
@@ -15,47 +15,47 @@ set fileencodings=utf-8,euc-jp,ucs-bom,iso-2022-jp,sjis,cp932,latin1
 set fileformats=unix,dos,mac
 
 " setting
-set autoread   " 編集中のファイルが変更されたら自動で読み直す
-set hidden     " バッファが編集中でもその他のファイルを開けるように
+set autoread   " Automatically reload the file when it is changed outside
+set hidden     " Allow opening other files even if the current buffer is modified
 set autochdir
 
 set guioptions+=a
 set clipboard^=unnamed,unnamedplus
 
-" vim が作る一時ファイルの場所
+" Location of temporary files created by vim
 set directory=$XDG_CONFIG_HOME/nvim/.temp
 set viminfo+=n$XDG_CONFIG_HOME/nvim/.temp/viminfo.txt
-set undofile                      " Undo ファイルを作成する
+set undofile                      " Create undo files
 set undodir=$XDG_CONFIG_HOME/nvim/.temp/undodir
 
-" backup ファイルの設定
+" Backup file settings
 " c.f. https://orebibou.com/2015/04/vim%E3%81%A7%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E4%BF%9D%E5%AD%98%E6%99%82%E3%81%AB%E4%BD%9C%E6%88%90%E3%81%95%E3%82%8C%E3%82%8B%E3%83%90%E3%83%83%E3%82%AF%E3%82%A2%E3%83%83%E3%83%97%E3%83%95/
-set backup                      " ファイルのバックアップを有効にする
-set writebackup                 " 取得するバックアップを編集前のファイルとする(無効化する場合は「nowritebackup」)
-set backupdir=$XDG_CONFIG_HOME/nvim/.backup  " このディレクトリはあらかじめ作っておく。chmod 700 するのを忘れずに
-" バックアップを取得するファイル名を「ファイル名.タイムスタンプ」とする
+set backup                      " Enable file backup
+set writebackup                 " Backup the file before it is edited (disable with "nowritebackup")
+set backupdir=$XDG_CONFIG_HOME/nvim/.backup  " Create this directory in advance. Don't forget to chmod 700 it
+" Use "filename.timestamp" as the backup file name
 " autocmd BufWritePre * let &backupext= '.' . strftime("%Y%m%d_%H%M%S")
 
-" 見た目系
-set number                " 行番号を表示
+" Appearance
+set number                " Show line numbers
 set relativenumber
-set ruler                 " ルーラーを表示
-" set cursorline            " 現在の行を強調表示
-" set cursorcolumn          " 現在の行を強調表示（縦）
-set title                 " タイトルを表示
-set virtualedit=onemore   " 行末の1文字先までカーソルを移動できるように
-set visualbell            " ビープ音を可視化
-set showmatch             " 括弧入力時の対応する括弧を表示
+set ruler                 " Show the ruler
+" set cursorline            " Highlight the current line
+" set cursorcolumn          " Highlight the current column
+set title                 " Show the window title
+set virtualedit=onemore   " Allow moving the cursor one character past the end of line
+set visualbell            " Visualize the bell instead of beeping
+set showmatch             " Show matching brackets when typing brackets
 set matchtime=1
 set matchpairs+=<:>
-set showcmd               " 入力中のコマンドをステータスに表示する
+set showcmd               " Show the command being typed in the status line
 set noshowmode
-set laststatus=2          " ステータスラインを常に表示
-" set nowrap                "テキストが折り返されないようにする
+set laststatus=2          " Always show the status line
+" set nowrap                " Do not wrap text
 set wrap
 set display=lastline
-set cursorline            " 現在の行をハイライト
-hi clear CursorLine       " 上と合わせることで行番号のみハイライト
+set cursorline            " Highlight the current line
+hi clear CursorLine       " Combined with the above, highlight only the line number
 set ambiwidth=double
 set signcolumn=auto
 set switchbuf=useopen
@@ -64,13 +64,13 @@ set conceallevel=2
 let g:tex_conceal=''
 set concealcursor=nc
 
-" 折りたたみ系
+" Folding
 " cf. https://maku77.github.io/vim/advanced/folding.html
-set foldmethod=indent  "折りたたみ範囲の判断基準（デフォルト: manual）
-set foldlevel=99       "ファイルを開いたときにデフォルトで折りたたむレベル (0: すべて折りたたむ 数値の分だけ折りたたまない)
-set foldcolumn=3       "左端に折りたたみ状態を表示する領域を追加する
+set foldmethod=indent  "Criteria for determining fold ranges (default: manual)
+set foldlevel=99       "Default fold level when a file is opened (0: fold everything, n: don't fold n levels)
+set foldcolumn=3       "Add a column on the left showing the fold state
 
-" " 折りたたみの自動保存
+" " Automatically save folds
 " " cf. https://vim-jp.org/vim-users-jp/2009/10/08/Hack-84.html
 " " Save fold settings.
 " autocmd BufWritePost * if expand('%') != '' && &buftype !~ 'nofile' | mkview | endif
@@ -78,90 +78,90 @@ set foldcolumn=3       "左端に折りたたみ状態を表示する領域を�
 " " Don't save options.
 " set viewoptions-=options
 
-" 折りたたみ設定etc.を保存するフォルダ
+" Directory for storing fold settings, etc.
 " set viewdir=$XDG_CONFIG_HOME/nvim/.temp/view
 
-" 補完系
+" Completion
 set wildmenu
-set wildmode=longest:full,full " コマンドラインの補完
-set pumheight=10          "変換候補で一度に表示される数を設定する
-set infercase             " 補完時に大文字小文字をいい感じに調節してくれる
+set wildmode=longest:full,full " Command line completion
+set pumheight=10          "Set the number of candidates shown at once in the popup menu
+set infercase             " Adjust case intelligently during completion
 
-" 言語ごとに追加の辞書を登録する
+" Register additional dictionaries per filetype
 " augroup fileTypeDictionary
 "     autocmd!
 "     autocmd FileType * execute 'setlocal dictionary+='. g:nvim_git_dir_path.'/userautoload/dictionary/'.&filetype.'.txt'
 " augroup END
 
-" Tab系
-set expandtab               " Tab文字を半角スペースにする
-set tabstop=2              " 行頭以外のTab文字の表示幅（スペースいくつ分）
-set shiftwidth=2            " 行頭でのTab文字の表示幅
-set softtabstop=2         " <Tab> の挿入や <BS> の使用等の編集操作をするときに、<Tab> が対応する空白の数。
+" Tabs
+set expandtab               " Use spaces instead of tab characters
+set tabstop=2              " Display width of tab characters not at the beginning of a line
+set shiftwidth=2            " Display width of tab characters at the beginning of a line
+set softtabstop=2         " Number of spaces a <Tab> corresponds to during editing operations such as inserting <Tab> or using <BS>
 
-" 言語ごとにTabの設定を変える
+" Change tab settings per filetype
 augroup fileTypeIndent
     autocmd!
 augroup END
 
-" 不可視文字を可視化(タブが「?-」と表示される)
+" Visualize invisible characters (tab displayed as "»-")
 set list
 set listchars=tab:»-,trail:-,eol:↲,extends:»,precedes:«,nbsp:⍽
 
 
-" 入力系
+" Input
 set textwidth=0
-set cindent           " インデントは C 形式のインデント
-set backspace=indent,eol,start " <BS> の挙動を変更
-set imdisable           " insert mode を抜けるときIMEをoffにする
+set cindent           " Use C-style indentation
+set backspace=indent,eol,start " Change <BS> behavior
+set imdisable           " Turn off the IME when leaving insert mode
 
-" 選択系
+" Selection
 set virtualedit=block
 
 " spellcheck
 set spell
-set spelllang=en,cjk "日本語を除外
+set spelllang=en,cjk " Exclude Japanese
 
-" 検索系
-set ignorecase " 検索文字列が小文字の場合は大文字小文字を区別なく検索する
-set smartcase  " 検索文字列に大文字が含まれている場合は区別して検索する
-set incsearch  " 検索文字列入力時に順次対象文字列にヒットさせる
-set wrapscan   " 検索時に最後まで行ったら最初に戻る
-set hlsearch   " 検索語をハイライト表示
+" Search
+set ignorecase " Ignore case if the search string is lowercase
+set smartcase  " Match case if the search string contains uppercase
+set incsearch  " Show incremental matches while typing the search string
+set wrapscan   " Wrap around to the top after reaching the bottom during search
+set hlsearch   " Highlight search matches
 
-set updatetime=100 " エディタの更新速度を速くする。
+set updatetime=100 " Speed up editor updates.
 
 " status line
 " references:
 " - https://blog.htkyama.org/vimrm
-" ファイル名表示
+" Show file name
 set statusline=%F
-" 変更チェック表示
+" Show modified flag
 set statusline+=%m
-" 読み込み専用かどうか表示
+" Show read-only flag
 set statusline+=%r
-" ヘルプページなら[HELP]と表示
+" Show [HELP] for help pages
 set statusline+=%h
-" プレビューウインドウなら[Prevew]と表示
+" Show [Preview] for preview windows
 set statusline+=%w
-" これ以降は右寄せ表示
+" Right-align the following
 set statusline+=%=
-" ファイルタイプ表示
+" Show file type
 set statusline+=%y
 " file encoding
 set statusline+=[%{&fileencoding}]
-" ファイルフォーマット表示
+" Show file format
 set statusline+=[%{&fileformat}]
-" 現在行数/全行数/パーセント
+" Current line/total lines/percent
 set statusline+=[L%l:C%c\ (%p%%)]
 
 " I like highlighting strings inside C comments.
 let c_comment_strings=1
 
-" 保存時に行末の空白を除去する
+" Remove trailing whitespace on save
 autocmd BufWritePre * :%s/\s\+$//ge
 
-" 保存時にタブをスペースに変換
+" Convert tabs to spaces on save
 autocmd BufWritePre * :retab
 
 " Enable file type detection.
@@ -195,19 +195,19 @@ if !exists(":DiffOrig")
                 \ | wincmd p | diffthis
 endif
 
-" vimdiff 関連
+" vimdiff settings
 set diffopt=internal,filler,algorithm:histogram,indent-heuristic
 
-" coc-setting.jsonの場所
+" Location of coc-setting.json
 let g:coc_config_home=expand('<sfile>:p:h:h').'/toml'
 
-" " エラーウィンドウを出す
+" " Show the error window
 " function! s:ale_list()
 "     let g:ale_open_list = 1
 "     call ale#Queue(0, 'lint_file')
 " endfunction
 " command! ALEList call s:ale_list()
-" オートコンパイル
+" Auto compile
 " augroup setAutoCompile
 "     autocmd!
 "     autocmd BufWritePost *.tex :!latexmk -lualatex %

--- a/nvim/userautoload/init/color.vim
+++ b/nvim/userautoload/init/color.vim
@@ -1,20 +1,20 @@
-"文字コードをUFT-8に設定
+" Set character encoding to UTF-8
 scriptencoding utf-8
 
 " let s:script_path = expand('<sfile>:p')
 " echom '[debug]enter ' . s:script_path
 
-" ウィンドウの縦幅
+" Window height
 " set lines=55
-" ウィンドウの横幅
+" Window width
 " set columns=180
-" カラースキーム
+" Color scheme
 "autocmd ColorScheme * highlight Search term=reverse cterm=reverse ctermfg=166 gui=reverse guifg=#FF8C00
 
 "cf. https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=2ahUKEwiU9Lq2wf7mAhXSG6YKHcnJDTYQFjAAegQIBRAB&url=https%3A%2F%2Fgithub.com%2Fxaizek%2Fdotvim%2Fblob%2Fmaster%2Fftdetect%2Fxaml.vim&usg=AOvVaw3fFHYZwsk5d0Pe1r63IWXW
 autocmd BufRead,BufNewFile *.xaml :set filetype=xml
 
-" JSONでコメントがhighlightされるようにする
+" Highlight comments in JSON
 autocmd FileType json syntax match Comment +\/\/.\+$+
 
 let g:markdown_fenced_languages = [
@@ -31,7 +31,7 @@ let g:markdown_fenced_languages = [
 \  'help'
 \]
 
-"全角スペースをハイライト表示
+" Highlight full-width spaces
 function! ZenkakuSpace()
     highlight ZenkakuSpace cterm=reverse ctermfg=DarkMagenta gui=reverse guifg=DarkMagenta
 endfunction
@@ -45,18 +45,18 @@ if has('syntax')
     call ZenkakuSpace()
 endif
 
-" 入力補完を半透明にする
+" Make the completion popup translucent
 set pumblend=20
 
 syntax enable
 colorscheme solarized8_dark_low
 set background=dark
 
-" Floating Window の色設定
+" Floating window color settings
 highlight! NormalFloat ctermbg=NONE guibg=#505050
 set winblend=20
 
-" 無色透明にする
+" Make fully transparent
 highlight! Normal ctermbg=NONE guibg=NONE
 highlight! NonText ctermbg=NONE guibg=NONE
 highlight! CursorLineNr ctermbg=NONE guibg=NONE
@@ -70,16 +70,16 @@ highlight! DiffAdd ctermbg=NONE guibg=NONE
 highlight! DiffChange ctermbg=NONE guibg=NONE
 highlight! DiffDelete ctermbg=NONE guibg=NONE
 
-" Comment を緑色にして見やすくする
+" Make comments green for readability
 highlight! Comment ctermfg=22 guifg=#3DB680
 
-" git commit のコメントを見やすくする
+" Make git commit comments more readable
 highlight! gitcommitComment ctermfg=22, guifg=#3DB680
 
-" cterm ではなく gui の色を使用する
+" Use gui colors instead of cterm colors
 set termguicolors
 
-" Cursor下のsyntax情報を取得する函数群
+" Functions to get syntax info under the cursor
 " cf. http://cohama.hateblo.jp/entry/2013/08/11/020849
 function! s:get_syn_id(transparent)
   let synid = synID(line("."), col("."), 1)

--- a/nvim/userautoload/init/mapping.vim
+++ b/nvim/userautoload/init/mapping.vim
@@ -1,18 +1,18 @@
 " memo
-" - <silent>を使うと、コマンドラインにコマンドが出力されないようになる。
+" - Using <silent> prevents the command from being printed on the command line.
 "   e.g
 "   - nnoremap <silent>sb :b#<CR>
-"   →一番下のラインには何も表示されない。
+"   -> nothing is shown on the bottom line.
 "   - nnoremap sb :b#<CR>
-"   →一番下のラインには :b# が表示されない。
+"   -> :b# is not shown on the bottom line.
 "
-"文字コードをUFT-8に設定
+" Set character encoding to UTF-8
 scriptencoding utf-8
 
 " let s:script_path = expand('<sfile>:p')
 " echom '[debug]enter ' . s:script_path
 
-" <Leader> を<Space> にする
+" Set <Leader> to <Space>
 let mapleader = "\<Space>"
 
 " Don't use Ex mode, use Q for formatting
@@ -22,7 +22,7 @@ noremap Q gq
 " so that you can undo CTRL-U after inserting a line break.
 inoremap <C-U> <C-G>u<C-U>
 
-" 折り返し時に表示行単位での移動できるようにする
+" Move by display line when wrapped
 nnoremap k   gk
 nnoremap j   gj
 vnoremap k   gk
@@ -30,23 +30,23 @@ vnoremap j   gj
 nnoremap gk  k
 nnoremap gj  j
 vnoremap gk  k
-" <C-l>にハイライト消去・ファイル変更適用効果を追加
+" Add highlight clearing and file change reload to <C-l>
 nnoremap <C-l> :nohlsearch<CR>:checktime<CR><Esc><C-l>
 nnoremap <Esc><Esc> :nohlsearch<CR>
-" 検索で使う規定の正規表現を Very Magic にする
+" Use Very Magic regex for search by default
 nmap / /\v
 
-" jj で insert mode を抜ける
+" Leave insert mode with jj
 inoremap jj <ESC>
 
-" WSLかどうかを判定する
+" Detect whether running under WSL
 " cf.https://moyapro.com/2018/03/21/detect-wsl/
 function! s:isWsl()
     return filereadable('/proc/sys/fs/binfmt_misc/WSLInterop')
 endfunction
 
-" 動かないので消す
-" insert mode を抜けるときIMEをオフにする
+" Removed because it doesn't work
+" Turn off the IME when leaving insert mode
 " cf.https://moyapro.com/2018/04/02/disable-ime-on-wsl-vim/
 " if s:isWsl() && executable('AutoHotkeyU64.exe')
 "     augroup insertLeave
@@ -55,11 +55,11 @@ endfunction
 "     augroup END
 " endif
 
-" 誤動作すると困るキーを無効にする
+" Disable keys that would cause trouble if accidentally pressed
 nnoremap ZZ <Nop>
 nnoremap ZQ <Nop>
 
-" 矢印キーを無効にする
+" Disable arrow keys
 noremap <Up> <Nop>
 noremap <Down> <Nop>
 noremap <Left> <Nop>
@@ -69,23 +69,23 @@ inoremap <Down> <Nop>
 inoremap <Left> <Nop>
 inoremap <Right> <Nop>
 
-" 行を移動
+" Move lines
 nnoremap <C-k> :m-2<cr>==
 nnoremap <C-j> :m+<cr>==
-" 複数行を移動
+" Move multiple lines
 xnoremap <C-k> :m-2<cr>gv=gv
 xnoremap <C-j> :m'>+<cr>gv=gvk
 
-" Yでカーソル位置から行末までヤンクする
+" Yank from cursor to end of line with Y
 nnoremap Y y$
 
-" x,Xでカーソル文字を削除する際レジスタを汚さない
+" Don't clobber the register when deleting the character under the cursor with x/X
 nnoremap x "_x
 vnoremap x "_x
 nnoremap X "_X
 vnoremap X "_X
 
-" s,Sでカーソル文字を削除する際レジスタを汚さない設定
+" Don't clobber the register when deleting the character under the cursor with s/S
 nnoremap s "_s
 vnoremap s "_s
 nnoremap S "_S
@@ -93,19 +93,19 @@ vnoremap S "_S
 
 " c.f. http://vimblog.hatenablog.com/entry/vimrc_key_mapping_examples
 
-" ビジュアルモードで < > キーによるインデント後にビジュアルモードが解除されないようにする
+" Keep visual mode active after indenting with < > keys
 vnoremap < <gv
 vnoremap > >gv
 
-" n, N キーで「次の（前の）検索候補」を画面の中心に表示する
+" Center the next (previous) search match on screen with n/N
 nnoremap n nzz
 nnoremap N Nzz
 
-" 数字のインクリメント/デクリメント
+" Increment/decrement numbers
 nnoremap + <C-a>
 nnoremap - <C-x>
 
-"押しにくい$及び^をリマッピング
+" Remap hard-to-reach $ and ^
 nmap H ^
 nmap L $
 vmap H ^
@@ -123,7 +123,7 @@ function! s:Repl()
 endfunction
 nmap <silent> <expr> p <sid>Repl()
 
-" ウィンドウ関連
+" Window related
 " c.f. https://qiita.com/tekkoc/items/98adcadfa4bdc8b5a6ca
 " c.f. http://ivxi.hatenablog.com/entry/2013/05/23/163825
 nnoremap s <Nop>
@@ -150,33 +150,33 @@ nnoremap <silent>sx :tabclose<CR>
 nnoremap <M-l> gt
 nnoremap <M-h> gT
 
-" function key 関連
+" Function key related
 
 " cf.
-" 相対行番号表示の切り替え
+" Toggle relative line numbers
 nnoremap <F12> :set relativenumber!<CR>
-" コマンドラインモードで %% を入力すると現在編集中のファイルのフォルダのパスが展開されるようにする
+" Expand %% to the path of the directory of the current file in command-line mode
 cnoremap %% <C-R>=expand('%:p:h').'/'<cr>
 
-" コマンドライン補完の選択キー
+" Keys for selecting command line completion
 set wildcharm=<TAB>
 cnoremap <expr> <TAB> pumvisible() ? "\<C-n>" : "\<TAB>"
 cnoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
 
 
-" terminal の設定
+" Terminal settings
 
-" 新しいタブでターミナルを起動
+" Open a terminal in a new tab
 nnoremap @t :tabe<CR>:terminal<CR>
-" Ctrl + q でターミナルを終了
+" Quit terminal with Ctrl+q
 tnoremap <C-q> <C-\><C-n>:q<CR>
-" ESC or jj でターミナルモードからノーマルモードへ
+" Return from terminal mode to normal mode with ESC or jj
 tnoremap <ESC> <C-\><C-n>
 tnoremap jj <C-\><C-n>
 vnoremap gj  j
 
 
-" オートコンパイルする
+" Auto compile
 " augroup setAutoCompile
 "     autocmd!
 "     autocmd BufWritePost *.tex  | :!latexmk -lualatex %

--- a/nvim/userautoload/init/plugins.vim
+++ b/nvim/userautoload/init/plugins.vim
@@ -3,36 +3,36 @@ scriptencoding utf-8
 " let s:script_path = expand('<sfile>:p')
 " echom '[debug]enter ' . s:script_path
 
-" Neovim設定ディレクトリ
+" Neovim config directory
 let nvim_dir = substitute(expand($XDG_CONFIG_HOME) . '/nvim/', '\', '/', 'g')
 
-" deinの関連のパス
+" dein related paths
 let dein_path = 'github.com/Shougo/dein.vim'
 let dein_url = 'https://' . dein_path
 
-" プラグインをインストールするディレクトリ
+" Directory where plugins are installed
 let s:dein_dir = nvim_dir . '.cache/dein/'
-" dein.vim 本体
+" dein.vim itself
 let s:dein_repo_dir = s:dein_dir . 'repos/' . dein_path
 
-" dein.vimがなければインストールする
+" Install dein.vim if it is not present
 if !isdirectory(s:dein_repo_dir)
   execute '!git clone ' . dein_url s:dein_repo_dir
 endif
-" dein.vimをruntimepathへ追加
+" Add dein.vim to runtimepath
 let &runtimepath = s:dein_repo_dir . ',' . &runtimepath
 
 
-" 設定開始
+" Start configuration
 if dein#load_state(s:dein_dir)
   call dein#begin(s:dein_dir)
 
-  " gitで管理しているtomlフォルダへのパス
+  " Path to the git-managed toml folder
   let s:toml_dir = expand('<sfile>:p:h:h').'/toml/'
-  " プラグインリストファイル
+  " Plugin list files
   let s:lazy_toml_dir = s:toml_dir . 'lazy/'
 
-  " プラグインリストを読み込みキャッシュする
+  " Load and cache the plugin list
   let s:toml_list = glob(s:toml_dir.'*.toml')
   let s:splitted = split(s:toml_list, '\n')
   for file in s:splitted
@@ -44,7 +44,7 @@ if dein#load_state(s:dein_dir)
     call dein#load_toml(file, {'lazy': 1})
   endfor
 
-  " 設定終了
+  " End configuration
   call dein#end()
   call dein#save_state()
 endif
@@ -52,18 +52,18 @@ endif
 filetype plugin indent on
 syntax enable
 
-" GitHub Personal Access Tokenを取得する
+" Retrieve the GitHub Personal Access Token
 
 " GitHub apt file.
 let s:github_pat = expand('<sfile>:p:h:h:h:h').'/github_pat'
-" github_patが有れば更新を確認し、pluginsをupdateする
+" If github_pat exists, check for updates and update plugins
 if filereadable(s:github_pat)
-  " ここで、g:dein#install_github_api_tokenにPATをセットする。
+  " Set the PAT to g:dein#install_github_api_token here.
   let g:dein#install_github_api_token = readfile(s:github_pat)[0]
   call dein#check_update('v:true')
 endif
 
-" 未インストールのプラグインがある場合はインストール
+" Install any not-yet-installed plugins
 if dein#check_install()
   call dein#install()
 endif

--- a/nvim/userautoload/snippets/cs.snippets
+++ b/nvim/userautoload/snippets/cs.snippets
@@ -73,7 +73,7 @@ namespace ${1:Application}
 
 		protected override void RegisterTypes(IContainerRegistry containerRegistry) { }
 
-		// "...Views.hogehoge.xaml" という View の View Model を "...ViewModels.hogehoge.cs" に自動で設定する
+		// Automatically map the View Model for a View named "...Views.hogehoge.xaml" to "...ViewModels.hogehoge.cs"
 		protected override void ConfigureViewModelLocator()
 		{
 			base.ConfigureViewModelLocator();
@@ -81,7 +81,7 @@ namespace ${1:Application}
 			ViewModelLocationProvider.
 				SetDefaultViewTypeToViewModelTypeResolver((viewType) =>
 			{
-				// "...Views.MainWindow" を "...ViewModels.MainWindow" に置き換える
+				// Replace "...Views.MainWindow" with "...ViewModels.MainWindow"
 				string viewName = viewType.FullName.Replace(".Views.",".ViewModels.");
 				string viewAssemblyName = viewType.GetTypeInfo().Assembly.FullName;
 				string viewModelName = $"{viewName}, {viewAssemblyName}";

--- a/nvim/userautoload/toml/context_filetype.toml
+++ b/nvim/userautoload/toml/context_filetype.toml
@@ -1,2 +1,2 @@
-[[plugins]] # カーソル位置のコンテキストのftを判定するライブラリ
+[[plugins]] # Library that determines the filetype based on the context at the cursor position
 repo = 'Shougo/context_filetype.vim'

--- a/nvim/userautoload/toml/deol.nvim.toml
+++ b/nvim/userautoload/toml/deol.nvim.toml
@@ -1,6 +1,6 @@
 [[plugins]]
 repo = 'Shougo/deol.nvim'
 hook_add='''
-" floating window でterminalを表示する。
+" Open a terminal in a floating window.
 nnoremap <silent><Leader>t :<C-u>Deol -split=floating<CR>
 '''

--- a/nvim/userautoload/toml/gina.vim.toml
+++ b/nvim/userautoload/toml/gina.vim.toml
@@ -15,11 +15,11 @@ nnoremap [GitMode]k :Gina push<CR>
 nnoremap [GitMode]j :Gina pull<CR>
 nnoremap [GitMode]J :Gina fetch<CR>
 
-" Gina log 上でのkey mappings
+" Key mappings in Gina log
 call gina#custom#mapping#nmap('log', '<CR>', ':call gina#action#call(''commit:checkout'')<CR>', {'noremap': 1, 'silent': 1})
 call gina#custom#mapping#nmap('log', 'dd', ':call gina#action#call(''commit:revert'')<CR>', {'noremap': 1, 'silent': 1})
 
-" Gina branch 上でのkey mappings
+" Key mappings in Gina branch
 call gina#custom#mapping#nmap('branch', 'm', ':call gina#action#call(''commit:merge:no-ff'')<CR>', {'noremap': 1, 'silent': 1})
 call gina#custom#mapping#nmap('branch', 'o', ':call gina#action#call(''branch:new'')<CR>', {'noremap': 1, 'silent': 1})
 call gina#custom#mapping#nmap('branch', 'dd', ':call gina#action#call(''branch:delete'')<CR>', {'noremap': 1, 'silent': 1})

--- a/nvim/userautoload/toml/lazy/cheatsheet.md
+++ b/nvim/userautoload/toml/lazy/cheatsheet.md
@@ -4,71 +4,71 @@
 
 ### note
 
-`<Leader>`は`<Space>`にしてある。
+`<Leader>` is set to `<Space>`.
 
 ### move
 
 #### cursor
 
-- `h` : 右
-- `j` : 下
-- `k` : 上
-- `l` : 左
+- `h` : Right
+- `j` : Down
+- `k` : Up
+- `l` : Left
 
 #### word
 
-- `w`   : 単語 記号区切り 次の先頭へ
-- `b`   : 単語 記号区切り 前の先頭へ
-- `e`   : 単語 記号区切り 次の末尾へ
-- `ge`  : 単語 記号区切り 前の末尾へ
-- `W`   : 単語 空白区切り 次の先頭へ
-- `B`   : 単語 空白区切り 前の先頭へ
-- `E`   : 単語 空白区切り 次の末尾へ
-- `gE`  : 単語 空白区切り 前の末尾へ
+- `w`   : Word, symbol-delimited, to the next start
+- `b`   : Word, symbol-delimited, to the previous start
+- `e`   : Word, symbol-delimited, to the next end
+- `ge`  : Word, symbol-delimited, to the previous end
+- `W`   : Word, whitespace-delimited, to the next start
+- `B`   : Word, whitespace-delimited, to the previous start
+- `E`   : Word, whitespace-delimited, to the next end
+- `gE`  : Word, whitespace-delimited, to the previous end
 
 #### line
 
-- `0`    : 行頭へ
-- `^`, `H` : 空白以外の行頭へ
-- `$`, `L` : 行末へ
+- `0`    : To the beginning of the line
+- `^`, `H` : To the beginning of the line (first non-whitespace)
+- `$`, `L` : To the end of the line
 
-- `<Leader>w`   : marker へ飛ぶ(単語 記号区切り cursor より次にある先頭)
-- `<Leader>b`   : marker へ飛ぶ(単語 記号区切り cursor より前にある先頭)
-- `<Leader>e`   : marker へ飛ぶ(単語 記号区切り cursor より次にある末尾)
-- `<Leader>ge`  : marker へ飛ぶ(単語 記号区切り cursor より前にある末尾)
-- `<Leader>W`   : marker へ飛ぶ(単語 空白区切り cursor より次にある先頭)
-- `<Leader>B`   : marker へ飛ぶ(単語 空白区切り cursor より前にある先頭)
-- `<Leader>E`   : marker へ飛ぶ(単語 空白区切り cursor より次にある末尾)
-- `<Leader>gE`  : marker へ飛ぶ(単語 空白区切り cursor より前にある末尾)
+- `<Leader>w`   : Jump to marker (word, symbol-delimited, next start after cursor)
+- `<Leader>b`   : Jump to marker (word, symbol-delimited, previous start before cursor)
+- `<Leader>e`   : Jump to marker (word, symbol-delimited, next end after cursor)
+- `<Leader>ge`  : Jump to marker (word, symbol-delimited, previous end before cursor)
+- `<Leader>W`   : Jump to marker (word, whitespace-delimited, next start after cursor)
+- `<Leader>B`   : Jump to marker (word, whitespace-delimited, previous start before cursor)
+- `<Leader>E`   : Jump to marker (word, whitespace-delimited, next end after cursor)
+- `<Leader>gE`  : Jump to marker (word, whitespace-delimited, previous end before cursor)
 
-- `<Leader>h{char}` : marker へ飛ぶ ({char}の真上 cursor より左)
-- `<Leader>l{char}` : marker へ飛ぶ ({char}の真上 cursor より右)
-- `<Leader>H{char}` : marker へ飛ぶ ({char}の前 cursor より左)
-- `<Leader>L{char}` : marker へ飛ぶ ({char}の前 cursor より右)
+- `<Leader>h{char}` : Jump to marker (directly above {char}, left of cursor)
+- `<Leader>l{char}` : Jump to marker (directly above {char}, right of cursor)
+- `<Leader>H{char}` : Jump to marker (before {char}, left of cursor)
+- `<Leader>L{char}` : Jump to marker (before {char}, right of cursor)
 
-- `f{char}` : marker へ飛ぶ ({char}の真上)
-- `t{char}` : marker へ飛ぶ ({char}の前)
+- `f{char}` : Jump to marker (directly above {char})
+- `t{char}` : Jump to marker (before {char})
 
 #### column
 
-- `<Leader>j` : marker へ飛ぶ (下)
-- `<Leader>k` : marker へ飛ぶ (上)
+- `<Leader>j` : Jump to marker (down)
+- `<Leader>k` : Jump to marker (up)
 
 #### object
 
-- `(`  : 文単位で上へ
-- `)`  : 文単位で下へ
-- `{`  : 段落単位で上へ
-- `}`  : 段落単位で下へ
-- `[[` : セクション単位で上へ
-- `]]` : セクション単位で下へ
+- `(`  : Up by sentence
+- `)`  : Down by sentence
+- `{`  : Up by paragraph
+- `}`  : Down by paragraph
+- `[[` : Up by section
+- `]]` : Down by section
 
 #### scroll
 
-- `<C-u>`             : 画面半分上へスクロール
-- `<C-d>`             : 画面半分下へスクロール
-- `<C-b>`, `<PageUp>`   : 1画面分上へスクロール
-- `<C-f>`, `<PageDown>` : 1画面分下へスクロール
+- `<C-u>`             : Scroll up half a screen
+- `<C-d>`             : Scroll down half a screen
+- `<C-b>`, `<PageUp>`   : Scroll up one screen
+- `<C-f>`, `<PageDown>` : Scroll down one screen
 
 #### mark
 
@@ -103,179 +103,179 @@ cf. https://github.com/kshenoy/vim-signature/blob/master/README.md
 
 #### other
 
-- `gg` : ファイル先頭へ
-- `G`  : ファイル末尾へ
-- `I`  : 行頭でインサートモードへ
-- `A`  : 行末でインサートモードへ
-- `S`  : 行を消してインサートモードへ
-- `J`  : 行をスペース区切りで結合(頭に数字で繰り返し)
-- `gJ` : 行を結合(頭に数字で繰り返し)
-- `<F12>` : 行表示切り替え(相対表示⇔絶対表示)
+- `gg` : To the beginning of the file
+- `G`  : To the end of the file
+- `I`  : Insert mode at the beginning of the line
+- `A`  : Insert mode at the end of the line
+- `S`  : Delete the line and enter insert mode
+- `J`  : Join lines separated by a space (prefix a number to repeat)
+- `gJ` : Join lines (prefix a number to repeat)
+- `<F12>` : Toggle line number display (relative to absolute)
 
 ### I/O
 
-- `:w` : 上書き保存
-- `:wa` : すべての buffer を上書き保存
-- `:q` : window を閉じる
-- `:qa` : vimを終了する
-- `:wq` : 上書き保存して window を閉じる
-- `:x` : 変更点があるときのみ上書き保存して window を閉じる
-- `:wqa`, `:xa` :すべての buffer を上書き保存して vim を終了する
+- `:w` : Save
+- `:wa` : Save all buffers
+- `:q` : Close the window
+- `:qa` : Quit vim
+- `:wq` : Save and close the window
+- `:x` : Save (only if modified) and close the window
+- `:wqa`, `:xa` : Save all buffers and quit vim
 
-- `:e {filename}` : {filename}を開く (相対パス/絶対パス両方可)
+- `:e {filename}` : Open {filename} (relative or absolute path)
 
 ### yank
 
-- `"0p` : レジスタ`"0`の内容を貼り付け(`"0`は`dd`などで削除しても使用されない)
+- `"0p` : Paste the contents of register `"0` (`"0` is not used when deleting with `dd` etc.)
 
 ### fold
 
-- ~`zf` : 新規作成~ 使用不可
-- `zo` : 開く
-- `zc` : 閉じる
-- `za` : 折りたたみ状態の切り替え
-- `zr` : ファイル全体を一段開く
-- `zR` : ファイル全体を全て開く
-- `zm` : ファイル全体を一段閉じる
-- `zM` : ファイル全体を全て閉じる
-- `zj` : 次の折りたたみ位置に進む
-- `zk` : 前の折りたたみ位置に戻る
-- `[z` : 現在開いている折り畳みの先頭へ移動
-- `]z` : 現在開いている折り畳みの末尾へ移動
+- ~`zf` : Create new~ not available
+- `zo` : Open
+- `zc` : Close
+- `za` : Toggle fold state
+- `zr` : Open one level of the whole file
+- `zR` : Open all folds of the whole file
+- `zm` : Close one level of the whole file
+- `zM` : Close all folds of the whole file
+- `zj` : Move to the next fold
+- `zk` : Move to the previous fold
+- `[z` : Move to the start of the current fold
+- `]z` : Move to the end of the current fold
 
 ### pane
 
-- `sv`: 縦に分割
-- `ss`: 横に分割
-- `sh`: 左のペインへ
-- `sj`: 下のペインへ
-- `sk`: 上のペインへ
-- `sl`: 右のペインへ
-- `sw`: 次のペインへ
-- `sH`: ペインを左に移動
-- `sJ`: ペインを下に移動
-- `sK`: ペインを上に移動
-- `sL`: ペインを右に移動
-- `sr`: ペインを回転
+- `sv`: Split vertically
+- `ss`: Split horizontally
+- `sh`: To the left pane
+- `sj`: To the lower pane
+- `sk`: To the upper pane
+- `sl`: To the right pane
+- `sw`: To the next pane
+- `sH`: Move pane to the left
+- `sJ`: Move pane down
+- `sK`: Move pane up
+- `sL`: Move pane to the right
+- `sr`: Rotate panes
 
 ### buffer
 
-- `sn`       : 次へ
-- `sp`       : 前へ
-- `sd`       : 削除
-- `:b {名前}` : 指定したバッファへ(補完可能)
+- `sn`       : Next
+- `sp`       : Previous
+- `sd`       : Delete
+- `:b {name}` : Switch to the specified buffer (completable)
 
 ### tab
 
-- `st`    : 空タブを新規作成
-- `<M-l>` : 次へ
-- `<M-h>` : 前へ
-- `sx`    : 削除
+- `st`    : Create a new empty tab
+- `<M-l>` : Next
+- `<M-h>` : Previous
+- `sx`    : Delete
 
 ### macro
 
-- `q(a-z)`       : 記録開始
-- `q`            : 記録終了
-- `[数字]@(a-z)` : 任意の回数分マクロを実行
+- `q(a-z)`       : Start recording
+- `q`            : Stop recording
+- `[number]@(a-z)` : Run the macro that many times
 
 ### coc.nvim
 
-- `<tab>` : 補完開始
-- `<C-j>` : ( snippet を展開できるとき ) snippet を展開する
-- `<C-j>` : ( snippet 展開中 ) 次の placefolder へ飛ぶ
-- `<C-k>` : ( snippet 展開中 ) 前の placefolder に戻る
-- `=G`    : LSP を使って code を整形する
-- `[c` : 前の警告へ飛ぶ
-- `]c` : 次の警告へ飛ぶ
+- `<tab>` : Start completion
+- `<C-j>` : (when a snippet can be expanded) expand the snippet
+- `<C-j>` : (while expanding a snippet) jump to the next placeholder
+- `<C-k>` : (while expanding a snippet) jump to the previous placeholder
+- `=G`    : Format code using LSP
+- `[c` : Jump to the previous warning
+- `]c` : Jump to the next warning
 
 ### location list
 
-- `:lop[en]`     : ロケーションリストを開く
-- `:lcl[ose]`    : ロケーションリストを閉じる
-- `:lne[xt]`     : 次へ
-- `:lp[revious]` : 前へ
+- `:lop[en]`     : Open the location list
+- `:lcl[ose]`    : Close the location list
+- `:lne[xt]`     : Next
+- `:lp[revious]` : Previous
 
 ### help
 
-- `:h[elp] ${name}`        : ヘルプを分割して表示
-- `:h[elp] ${name} | only` : ヘルプを全画面で表示
-- `<C-]>`                  : 項目へジャンプ
-- `<C-o>`                  : 元の場所へ戻る
-- `K`                      : カーソル位置のキーワードを調べる
-- `<F1>`                   : このcheat sheetを開閉する
+- `:h[elp] ${name}`        : Show help in a split window
+- `:h[elp] ${name} | only` : Show help fullscreen
+- `<C-]>`                  : Jump to the item
+- `<C-o>`                  : Go back to the previous location
+- `K`                      : Look up the keyword under the cursor
+- `<F1>`                   : Toggle this cheat sheet
 
 ### EasyMotion
 
-- `;{char}{char}{label}` : ;のあとに続けた二文字がある場所にカーソルを飛ばす。複数箇所ある場合はジャンプ用のlabelsを表示する
-- `f{char}{label}` : 現在行内で、カーソルの右にある{char}に飛ぶ。複数箇所あるときはlabelsを表示する。
-- `F{char}{label}` : 現在行内で、カーソルの左にある{char}に飛ぶ。複数箇所あるときはlabelsを表示する。
-- `<leader>k{label}` : {label}が表示されている行に飛ぶ。範囲はカーソルより上の行
-- `<leader>j{label}` : {label}が表示されている行に飛ぶ。範囲はカーソルより下の行
+- `;{char}{char}{label}` : Jump to the position of the two characters typed after `;`. If there are multiple positions, jump labels are shown
+- `f{char}{label}` : Jump to {char} to the right of the cursor on the current line. If there are multiple positions, labels are shown
+- `F{char}{label}` : Jump to {char} to the left of the cursor on the current line. If there are multiple positions, labels are shown
+- `<leader>k{label}` : Jump to the line where {label} is shown, above the cursor
+- `<leader>j{label}` : Jump to the line where {label} is shown, below the cursor
 
 ### Denite
 
 - `:Dgrep`   : Denite grep
-- `:Dresume` : 閉じた検索結果を再度開く
-- `:Dprev`   : 前の検索結果へ
-- `:Dnext`   : 次の検索結果へ
-- `<C-n>`    : (検索結果ダイアログ)次へ
-- `<C-p>`    : (検索結果ダイアログ)前へ
+- `:Dresume` : Reopen the closed search results
+- `:Dprev`   : To the previous search result
+- `:Dnext`   : To the next search result
+- `<C-n>`    : (search result dialog) next
+- `<C-p>`    : (search result dialog) previous
 
 ### Defx
 
-- `<C-u>` : defx を開く
+- `<C-u>` : Open defx
 
-以下、defx buffer 内でのみ有効
+The following are only valid inside the defx buffer
 
-- `h`       : 親 directory に戻る
-- `j`       : 下に進む
-- `k`       : 上に戻る
-- `l`, `<CR>` : cursor 行の file/directory を開く
-- `E`      : windowを垂直分割してfileを左のpaneで開く
-- `~`       : root directory に飛ぶ
-- `o`       : file tree の展開の切り替え
-- `N`       : file を新規作成
-- `M`       : file を新規作成 (複数個)
-- `K`       : directory を新規作成
-- `r`       : 名前変更
-- `d`       : file/directoryを削除
-- `c`       : file/directoryをcopy
-- `m`       : file/directoryを切り取る
-- `p`       : copy・切り取りしたfile/directoryを貼り付ける
-- `C`       : 詳細情報の表示切り替え
-- `S`        : 更新日時順に並び替える
-- `cd`      : 現在地点を vim の current directory にする
-- `!{command}<CR>`: shell commandを実行する
-- `yy`           : cursor行のfile/directoryのpathをyankする
-- `<Space>`        : cursor行のfile/directoryを選択肢しcursorを一つ下に移動させる
+- `h`       : Go back to the parent directory
+- `j`       : Move down
+- `k`       : Move up
+- `l`, `<CR>` : Open the file/directory on the cursor line
+- `E`      : Open the file in the left pane with a vertical split
+- `~`       : Jump to the root directory
+- `o`       : Toggle file tree expansion
+- `N`       : Create a new file
+- `M`       : Create new files (multiple)
+- `K`       : Create a new directory
+- `r`       : Rename
+- `d`       : Delete file/directory
+- `c`       : Copy file/directory
+- `m`       : Cut file/directory
+- `p`       : Paste the copied/cut file/directory
+- `C`       : Toggle detailed information display
+- `S`        : Sort by modification time
+- `cd`      : Make the current location vim's current directory
+- `!{command}<CR>`: Run a shell command
+- `yy`           : Yank the path of the file/directory on the cursor line
+- `<Space>`        : Select the file/directory on the cursor line and move the cursor down
 
-- `q` : defx を閉じる
+- `q` : Close defx
 
 ### git
 
-- `<Leader>gs`      : statusを表示
-- `<Leader>gb`      : branchを表示
-- `<Leader>gl`      : logを表示
-- `<Leader>gc`      : commit編集windowを表示
-- `<Leader>gm`      : cursor位置に関するcommit messageを表示
+- `<Leader>gs`      : Show status
+- `<Leader>gb`      : Show branches
+- `<Leader>gl`      : Show log
+- `<Leader>gc`      : Show the commit edit window
+- `<Leader>gm`      : Show the commit message for the cursor position
 
 ### vim-go
 
-- `:GoImport ${name}` : importに追加、tab補完可能
-- `:GoDrop ${name}`   : importから削除、tab補完可能
-- `:GoImports`        : 不足しているパッケージをimportに追加する
-- `dif`               : 関数の中身をdelete
-- `vif`               : 関数の中身を選択
-- `yif`               : 関数の中身をyank
-- `daf`               : 関数の全体をdelete
-- `vaf`               : 関数の全体を選択
-- `yaf`               : 関数の全体をyank
-- `:GoAlternate`      : foo.go と foo_test.goを行き来する
-- `:GoDef`            : 定義へ移動
-- `:GoDoc`            : ドキュメントを開く
-- `:GoDocBrowser`     : ドキュメントをブラウザで開く
-- `<Leader>i`         : GoInfo = カーソル下の情報を表示
-- `:GoRename`         : カーソル下の要素をリネーム
+- `:GoImport ${name}` : Add to imports, tab completion available
+- `:GoDrop ${name}`   : Remove from imports, tab completion available
+- `:GoImports`        : Add missing packages to imports
+- `dif`               : Delete the function body
+- `vif`               : Select the function body
+- `yif`               : Yank the function body
+- `daf`               : Delete the whole function
+- `vaf`               : Select the whole function
+- `yaf`               : Yank the whole function
+- `:GoAlternate`      : Switch between foo.go and foo_test.go
+- `:GoDef`            : Jump to definition
+- `:GoDoc`            : Open documentation
+- `:GoDocBrowser`     : Open documentation in a browser
+- `<Leader>i`         : GoInfo = show info under the cursor
+- `:GoRename`         : Rename the element under the cursor
 
 ## c.f
 

--- a/nvim/userautoload/toml/lazy/denite.nvim.toml
+++ b/nvim/userautoload/toml/lazy/denite.nvim.toml
@@ -4,7 +4,7 @@ hook_add='''
 nnoremap [Denite] <Nop>
 nmap <Leader>d [Denite]
 
-" 大文字のときは検索を自動で開始させておく
+" Start filtering automatically with the uppercase mappings
 nnoremap <silent> [Denite]a :<C-u>Denite file buffer file:new<CR>
 nnoremap <silent> [Denite]A :<C-u>Denite file buffer file:new -start-filter<CR>
 nnoremap <silent> [Denite]b :<C-u>Denite buffer file:new<CR>
@@ -24,7 +24,7 @@ nnoremap <silent> [Denite]H :<C-u>Denite help -start-filter<CR>
 nnoremap <silent> [Denite]m :<C-u>Denite mark<CR>
 '''
 hook_source='''
-" Denite の default options
+" Denite default options
 " cf. https://qiita.com/reireias/items/a15f43dbbf7c88aeaf99
 let s:denite_win_width_percent = 0.85
 let s:denite_win_height_percent = 0.7
@@ -36,7 +36,7 @@ let s:denite_default_options = {
     \ 'highlight_filter_background': 'DeniteFilter',
     \ 'prompt': '$ ',
     \ }
-" default options を登録する
+" Register the default options
 let s:denite_option_array = []
 for [key, value] in items(s:denite_default_options)
   call add(s:denite_option_array, '-'.key.'='.value)

--- a/nvim/userautoload/toml/lazy/undotree.toml
+++ b/nvim/userautoload/toml/lazy/undotree.toml
@@ -1,17 +1,17 @@
 [[plugins]]
 repo = 'mbbill/undotree'
 hook_source = '''
-let g:undotree_WindowLayout = 1         " undotreeは左側/diffは下にウィンドウ幅で表示
-let g:undotree_ShortIndicators = 1      " 時間単位は短く表示
-let g:undotree_SplitWidth = 10          " undotreeのウィンドウ幅
-let g:undotree_SetFocusWhenToggle = 1   " undotreeを開いたらフォーカスする
-"let g:undotree_DiffAutoOpen = 0         " diffウィンドウは起動時無効
-let g:undotree_DiffpanelHeight = 5      " diffウィンドウの行数
-"let g:undotree_HighlightChangedText = 0 " 変更箇所のハイライト無効
-" undotreeをトグル表示
+let g:undotree_WindowLayout = 1         " undotree on the left, diff window below
+let g:undotree_ShortIndicators = 1      " Show short time indicators
+let g:undotree_SplitWidth = 10          " Width of the undotree window
+let g:undotree_SetFocusWhenToggle = 1   " Focus the undotree window when opened
+"let g:undotree_DiffAutoOpen = 0         " Disable the diff window at startup
+let g:undotree_DiffpanelHeight = 5      " Height of the diff window
+"let g:undotree_HighlightChangedText = 0 " Disable highlighting of changed text
+" Toggle undotree
 noremap <Leader>u :UndotreeToggle<CR>
 
-" undotreeバッファ内でのキーバインド設定
+" Key bindings inside the undotree buffer
 function! g:Undotree_CustomMap()
     nmap <silent> <buffer> <Esc> q
     nmap <silent> <buffer> h ?

--- a/nvim/userautoload/toml/lightline.vim.toml.disabled
+++ b/nvim/userautoload/toml/lightline.vim.toml.disabled
@@ -30,16 +30,16 @@ let g:lightline = {
             \ 'subseparator': { 'left': '', 'right': '' }
             \ }
 
-" 特殊バッファとして認識するfiletypes
+" Filetypes treated as special buffers
 let s:ignore_types='defx\|help\|undotree\|gina-*'
 
-" winwidth に関するメモ：
-" - winwidth >130: 通常モード
-" - winwidth > 100: 短縮表示
-" - otherwise     : 表示しない
+" Notes on winwidth:
+" - winwidth >130: full mode display
+" - winwidth > 100: shortened display
+" - otherwise     : hidden
 
 function! LightLineMode()
-    " windowの幅が狭いときは、modeを短縮表示する
+    " Show a shortened mode when the window is narrow
     if winwidth(0)>100
         let mode_name=lightline#mode()
     else
@@ -164,12 +164,12 @@ let g:lightline.tab_component_function = {
             \ 'readonly': 'lightline#tab#readonly',
             \ 'tabnum': 'lightline#tab#tabnum' }
 
-" 特殊バッファと読み取り専用ファイルに対して、読み取り専用マークを表示する。
+" Show the read-only mark for special buffers and read-only files.
 function! LightLineReadonly()
     return &filetype =~ s:ignore_types || &readonly ? '' :&filetype ==  ''
 endfunction
 
-" 保存していない変更があったら+マークを表示する
+" Show a + mark if there are unsaved changes
 function! LightLineModified()
     return &filetype !~s:ignore_types && &modified ? '+' : ''
 endfunction

--- a/nvim/userautoload/toml/vim-precious.toml
+++ b/nvim/userautoload/toml/vim-precious.toml
@@ -1,3 +1,3 @@
-[[plugins]] # カーソル位置のコンテキストに合わせてftを切り替える
+[[plugins]] # Switch the filetype according to the context at the cursor position
 repo = 'osyo-manga/vim-precious'
 depends = ['context_filetype.vim']

--- a/nvim/userautoload/toml/vim-submode.toml
+++ b/nvim/userautoload/toml/vim-submode.toml
@@ -2,16 +2,16 @@
 repo = 'kana/vim-submode'
 hook_add = '''
 
-" statusline に表示するようにしたのでいらない
+" No longer needed because it is shown in the statusline
 " let g:submode_always_show_submode = 1 " show always the current submode
 let g:submode_timeout = 0            " disable time out on submodes
 let g:submode_keep_leaving_key=v:true
 
 " cf. https://qiita.com/tekkoc/items/98adcadfa4bdc8b5a6ca#vimrc
-" s>:windowの幅を増やす
-" s<:windowの幅を減らす
-" s+:windowの高さを増やす
-" s-:windowの高さを減らす
+" s>: increase window width
+" s<: decrease window width
+" s+: increase window height
+" s-: decrease window height
 call submode#enter_with('WINSIZE', 'n', '', 's>', '<C-w>>')
 call submode#enter_with('WINSIZE', 'n', '', 's<', '<C-w><')
 call submode#enter_with('WINSIZE', 'n', '', 's+', '<C-w>+')


### PR DESCRIPTION
Translate all Japanese comments, echo messages, and documentation in the repo into English.

- .commit_template, .inputrc, install.sh
- nvim config files (ginit.vim, init.vim, userautoload/*)
- toml plugin configs and cheatsheet.md

Note: the UTF-8 glyph test file (utf8-markus-kuhn-plus-webdevicon-glyphs.txt) keeps its Japanese sample character, as it is test data for glyph rendering.