### PR TITLE
fix: replace builtins.currentSystem with per-system homeConfigurations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
               echo "Updating flake..."
               nix flake update
               echo "Updating home-manager..."
-              nix run .#home-manager -- switch --flake .#takker
+              nix run .#home-manager -- switch --flake ".#takker-${system}"
               echo "Update complete!"
             ''
           );
@@ -65,10 +65,27 @@
       }
     )
     // {
-      homeConfigurations.takker = home-manager.lib.homeManagerConfiguration {
-        pkgs = import nixpkgs { system = builtins.currentSystem; };
-        extraSpecialArgs = { inherit inputs; };
-        modules = [ ./nix/home-manager/default.nix ];
-      };
+      homeConfigurations =
+        let
+          mkConfig =
+            sys:
+            home-manager.lib.homeManagerConfiguration {
+              pkgs = nixpkgs.legacyPackages.${sys};
+              extraSpecialArgs = { inherit inputs; };
+              modules = [ ./nix/home-manager/default.nix ];
+            };
+        in
+        builtins.listToAttrs (
+          map
+            (sys: {
+              name = "takker-${sys}";
+              value = mkConfig sys;
+            })
+            [
+              "aarch64-linux"
+              "x86_64-linux"
+              "aarch64-darwin"
+            ]
+        );
     };
 }


### PR DESCRIPTION
## Summary
`builtins.currentSystem` is intentionally unavailable in flake pure evaluation (Nix 2.21+). This PR removes its usage.

## Changes
- Generate `homeConfigurations` per system: `takker-x86_64-linux`, `takker-aarch64-linux`, `takker-aarch64-darwin` using `nixpkgs.legacyPackages`
- Update the update script to reference `.#takker-${system}` — `${system}` is baked in at build time inside `eachSystem`

## Why not inside eachSystem?
home-manager's `--flake` only looks at top-level `homeConfigurations`, so per-system naming is used instead.
## References
- https://discourse.nixos.org/t/fixing-error-attribute-currentsystem-missing-in-flake/22386
- https://github.com/NixOS/nixpkgs/issues/303736