### PR TITLE
fix(gh): link config.yml to a writable file in the repo

### DIFF
--- a/gh/config.yml
+++ b/gh/config.yml
@@ -1,0 +1,7 @@
+aliases:
+    co: pr checkout
+    pv: pr view
+editor: ''
+git_protocol: https
+prompt: enabled
+version: 1

--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -2,6 +2,7 @@
   inputs,
   config,
   pkgs,
+  lib,
   ...
 }:
 let
@@ -142,17 +143,14 @@ in
 
     gh = {
       enable = true;
-      settings = {
-        git_protocol = "https";
-
-        prompt = "enabled";
-
-        aliases = {
-          co = "pr checkout";
-          pv = "pr view";
-        };
-      };
     };
+  };
+
+  # gh CLI expects to own config.yml (it writes git_protocol etc. during
+  # auth/login), so link it to a real, writable file in this repo instead of a
+  # read-only store path.
+  xdg.configFile."gh/config.yml" = lib.mkForce {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/gh/config.yml";
   };
 
 }


### PR DESCRIPTION
home-manager previously generated config.yml as a read-only store symlink, which broke `gh auth login` (permission denied). Link it to gh/config.yml in this repo via mkOutOfStoreSymlink and remove settings from the module.
