### PR TITLE
feat(opencode): manage opencode config from dotfiles repo

### DIFF
--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -153,4 +153,13 @@ in
     source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/gh/config.yml";
   };
 
+  # opencode config is version-controlled in this repo, but opencode may write
+  # node_modules/package.json next to it, so link the file (not the whole
+  # directory) to a writable out-of-store path. Add agent/command files here as
+  # the need arises.
+  xdg.configFile."opencode/opencode.jsonc" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/opencode/opencode.jsonc";
+    force = true;
+  };
+
 }

--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": true,
+  "mcp": {}
+}


### PR DESCRIPTION
## Summary

- Add `opencode/opencode.jsonc` to the dotfiles repo (migrated from `~/.config/opencode/`)
- Link it via home-manager `xdg.configFile` with `mkOutOfStoreSymlink`, same pattern as `gh/config.yml` (writable, out-of-store)
- Link the file only (not the directory) since opencode writes `package.json`/`node_modules` next to it
- `~/.config/opencode/` now stays functional immediately; run ``dotfiles-switch`` to bring it under home-manager management

Note: `/home/takker/.config/opencode/opencode.jsonc` was manually replaced with a symlink already.