### PR TITLE
fix(nixd): Enable the global nix server setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "nix.enableLanguageServer": true,
-  "nix.serverPath": "nixd"
-}


### PR DESCRIPTION
Removed `.vscode/settings.json`. Instead we need to add `"nix.serverPath": "${env:HOME}/.nix-profile/bin/nixd",` to global `settings.json`.