### PR TITLE
feat: cosense skill for opencode

### DIFF
--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -60,6 +60,7 @@ in
       uv
       cargo
       deno
+      nodejs
       pnpm
       neovim # nightly
       opencode

--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -1,5 +1,8 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "lsp": true,
+  "skills": {
+    "paths": ["~/git/cosense-cli/skills/cosense"]
+  },
   "mcp": {}
 }


### PR DESCRIPTION
opencode に cosense skill を追加します

- opencode/opencode.jsonc: skills.paths に cosense skill を追加
- nix/home-manager/default.nix: cosense CLI 実行に必要な nodejs を追加